### PR TITLE
!feat: Allow Renovate to update Github Actions Runner version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,7 @@
 FROM ubuntu:22.04@sha256:19478ce7fc2ffbce89df29fea5725a8d12e57de52eb9ea570890dc5852aac1ac
 
-ARG RUNNER_VERSION="2.316.0"
+# renovate: datasource=github-releases depName=github-actions-runner packageName=actions/runner
+ENV RUNNER_VERSION=2.316.0
 
 ARG DEBIAN_FRONTEND=noninteractive
 

--- a/renovate.json
+++ b/renovate.json
@@ -18,5 +18,15 @@
       "matchDepTypes": ["devDependencies"],
       "automerge": true
     }
+  ],
+  "customManagers": [
+    {
+      "customType": "regex",
+      "description": "Update _VERSION variables in Dockerfiles",
+      "fileMatch": ["(^|/|\\.)Dockerfile$", "(^|/)Dockerfile\\.[^/]*$"],
+      "matchStrings": [
+        "# renovate: datasource=(?<datasource>[a-z-]+?)(?: depName=(?<depName>.+?))? packageName=(?<packageName>.+?)(?: versioning=(?<versioning>[a-z-]+?))?\\s(?:ENV|ARG) .+?_VERSION=(?<currentValue>.+?)\\s"
+      ]
+    }
   ]
 }


### PR DESCRIPTION
- Add `customManager` regex configuration to allow Github Actions Runner depedancy to be auto updated